### PR TITLE
Update threads.sql

### DIFF
--- a/threads.sql
+++ b/threads.sql
@@ -1,6 +1,6 @@
 CREATE TABLE threads (
 	id BIGSERIAL primary key,
-	title VARCHAR(64) not null,
+	title VARCHAR(256) not null,
 	timestamp timestamp without time zone default (now() at time zone 'utc') not null,
 	locked boolean DEFAULT false not null,
 	subcategory_id int not null,


### PR DESCRIPTION
64 characters is quite short for a title, make it a bit longer? I was getting a 500 response if the title was too long
